### PR TITLE
delete image from disk storage & preview image base on url

### DIFF
--- a/backend/app/Http/Controllers/vendorController.php
+++ b/backend/app/Http/Controllers/vendorController.php
@@ -6,6 +6,7 @@ use App\Models\Product;
 use App\Models\ProductImage;
 use App\Models\ShopVendor;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator;
 use PhpParser\Builder\Function_;
 
@@ -205,26 +206,58 @@ class vendorController extends Controller
         $vendor = request()->user();
 
         $product = Product::where('id', $id)->where('shopvendor_id', $vendor->id)->first();
+        $productImages = ProductImage::where("product_id", $id)->get();
 
         if (!$product) {
             return response()->json([
-                'status' => 422,
                 'message' => 'No Product found'
-            ], 422);
-        }
-
-        if ($product->delete()) {
-            # code...
-            return response()->json([
-                'status' => 201,
-                'message' => 'Product deleted successfully!'
-            ], 210);
-        } else {
-            return response()->json([
-                'status' => 404,
-                'message' => 'An error occured deleting product'
             ], 404);
         }
+
+        $deleteProduct = $product->delete();
+
+        if (!$deleteProduct) {
+            return response()->json([
+                'status' => 404,
+                'message' => 'An error occured while deleting product'
+            ], 404);
+        }
+
+        foreach ($productImages as $image) {
+            $productImageExist = Storage::disk("public")->exists($image["image"]);
+
+            if ($productImageExist) {
+                Storage::disk("public")->delete($image["image"]);
+            }
+        }
+
+        return response()->json([
+            'message' => 'Product deleted successfully!'
+        ], 210);
+    }
+
+
+
+    public function previewProductImage(Request $request)
+    {
+        if (!$request->query("image")) {
+            return response()->json(["error" => "image query need to get image"], 400);
+        }
+
+
+        $productImage = ProductImage::where("image", $request->query("image"))->first();
+
+        if (!$productImage) {
+            return response()->json(["error" => "Image not found"], 404);
+        }
+
+        $imagePath = $productImage->image;
+
+        if (!Storage::disk("public")->exists($imagePath)) {
+            return response()->json(["error" => "Image not found on disk storage"], 404);
+        };
+
+        return response()->file(Storage::disk("public")->path($imagePath));
     }
 
     public function vendorlogout(Request $request)

--- a/backend/resources/views/productForm.blade.php
+++ b/backend/resources/views/productForm.blade.php
@@ -103,7 +103,7 @@
                 contentType: false,
                 headers: {
                     "Authorization": "Bearer " +
-                        "1|iKnVLV6pQshpsaUNJyvaCGU5AQDIw6uBzvDv9c0X9fcccff8"
+                        "4|1Tlm5fTN0TmrhXTWz0mCZ3lkmfy53qZte8dVZzIu35142f91"
                 },
                 success: function(response) {
                     alert(response.message);

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -56,6 +56,8 @@ Route::middleware(['auth:sanctum'])->group(function () {
     //admin to add categories 
 });
 
+
+Route::get("/vendor/product/preview-image", [vendorController::class, "previewProductImage"]);
 //search option  
 Route::get('/test/image-upload', function () {
     return view('productForm');


### PR DESCRIPTION
- When a vendor delete a product the images of the product will be deleted ,since such product does not exist. there is no need to have it images on the disk as this will be a burden to the system. 

- Product image can viewed base on a url endpoint
eg. http://127.0.0.1:8000/api/vendor/product/preview-image?image=product-images/seFich63tTlwgyAwGYTKCaW0Z25ObfnUeHJh73ud.jpg