### PR TITLE
delete image from disk storage & preview image base on url

### DIFF
--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -62,6 +62,8 @@ Route::post("/vendor/product/search-category", [vendorController::class, "search
 Route::get("/vendor/product/search-price", [vendorController::class, "searchProductByPriceRange"]);
 
 
+Route::get("/product/preview-image", [vendorController::class, "previewProductImage"]);
+
 //search option  
 Route::get('/test/image-upload', function () {
     return view('productForm');


### PR DESCRIPTION
When a vendor delete a product the images of the product will be deleted ,since such product does not exist. there is no need to have it images on the disk as this will be a burden to the system.

Product image can viewed base on a url endpoint
eg. http://127.0.0.1:8000/api/vendor/product/preview-image?image=product-images/seFich63tTlwgyAwGYTKCaW0Z25ObfnUeHJh73ud.jpg